### PR TITLE
fixed the bug we introduced

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
         version: 1.0
 
 source:
-        path: src
+        path: ../src
 
 requirements:
         build:


### PR DESCRIPTION
The recipe wasn't building because of a damaged path variable in meta.yaml.  This has been fixed and tested with conda-build and the repo now builds properly.